### PR TITLE
Pin numpy >=2.0

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # core functionality
   - python=3.11
-  - numpy>=1.24,<2.0
+  - numpy>=2.0
   - jax>=0.4.0
   - jaxlib>=0.4.0
   # Visualisation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
   "jax>=0.4.0",
   "jaxlib>=0.4.0",
-  "numpy>=1.24,<2.0",
+  "numpy>=2.0",
   "matplotlib>=3.7.0",
 ]
 


### PR DESCRIPTION
Tested locally: Tests still work, no issues with the new numpy release.