### PR TITLE
Development: CalVer and automation

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,9 +1,9 @@
 [bumpversion]
 current_version = "2025.04.0"
 version_pattern = "calver"
-parse = "^(?P<year>\d{4})\.(?P<month>\d{2})\.(?P<patch>\d+)$"
+parse = "^(?P<year>\\d{4})\\.(?P<month>\\d{2})\\.(?P<patch>\\d+)$"
 serialize = [
-  "{year}.{month}.{patch}",
+  "{year}.{month}.{patch}"
 ]
 tag = true
 tag_name = "v{new_version}"
@@ -20,5 +20,5 @@ month.format = "%m"
 patch.type = "integer"
 
 [bumpversion.files]
-pyproject.toml = []
+pyproject.toml = { search = 'version = "2025.04.0"', replace = 'version = "{new_version}"' }
 "src/cpax/__init__.py" = []

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,24 +1,28 @@
-[bumpversion]
+[tool.bumpversion]
 current_version = "2025.04.0"
-version_pattern = "calver"
-parse = "^(?P<year>\\d{4})\\.(?P<month>\\d{2})\\.(?P<patch>\\d+)$"
-serialize = [
-  "{year}.{month}.{patch}"
-]
-tag = true
-tag_name = "v{new_version}"
-commit = true
-message = "Release: {new_version}"
+parse           = "^(?P<year>\\d{4})\\.(?P<month>\\d{2})\\.(?P<patch>\\d+)$"
+serialize       = ["{year}.{month}.{patch}"]
+tag             = true
+tag_name        = "v{new_version}"
+commit          = true
+message         = "Release: {new_version}"
 
-[bumpversion.parts]
-year.type = "calver"
-year.format = "%Y"
+[tool.bumpversion.parts.year]
+type           = "calver"
+calver_format  = "%Y"
 
-month.type = "calver"
-month.format = "%m"
+[tool.bumpversion.parts.month]
+type           = "calver"
+calver_format  = "%m"
 
-patch.type = "integer"
+[tool.bumpversion.parts.patch]
+type           = "integer"
 
-[bumpversion.files]
-pyproject.toml = { search = 'version = "2025.04.0"', replace = 'version = "{new_version}"' }
-"src/cpax/__init__.py" = []
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search   = 'version = "2025.04.0"'
+replace  = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "src/cpax/__init__.py"
+ignore_missing_version = true

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = "2025.05.02"
+current_version = "2025.04.0"
 version_pattern = "calver"
 parse = "^(?P<year>\d{4})\.(?P<month>\d{2})\.(?P<patch>\d+)$"
 serialize = [

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -1,0 +1,24 @@
+# .github/workflows/manual-release.yml
+name: Manual CalVer Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install bump-my-version
+        run: pip install bump-my-version
+
+      - name: Bump version
+        run: |
+          bump-my-version bump patch
+          git push origin HEAD --follow-tags

--- a/bumpversion.toml
+++ b/bumpversion.toml
@@ -1,0 +1,24 @@
+[bumpversion]
+current_version = "2025.05.02"
+version_pattern = "calver"
+parse = "^(?P<year>\d{4})\.(?P<month>\d{2})\.(?P<patch>\d+)$"
+serialize = [
+  "{year}.{month}.{patch}",
+]
+tag = true
+tag_name = "v{new_version}"
+commit = true
+message = "Release: {new_version}"
+
+[bumpversion.parts]
+year.type = "calver"
+year.format = "%Y"
+
+month.type = "calver"
+month.format = "%m"
+
+patch.type = "integer"
+
+[bumpversion.files]
+pyproject.toml = []
+"src/cpax/__init__.py" = []

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,11 +9,13 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../../src'))
+import importlib.metadata
 
 project = 'CPax'
 copyright = '2025, Jan Lukas Späh'
 author = 'Jan Lukas Späh'
-release = 'v2025.4.0'
+release = importlib.metadata.version("cpax")
+version = ".".join(release.split(".")[:2])
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "CPax"
-version = "2025.5.0"
+version = "2025.4.0"
 description = "CPax: A JAX-based computational physics library."
 authors = [
   { name = "Jan Lukas Späh", email = "your.email@example.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "CPax"
-version = "2025.4.0"
+version = "2025.04.0"
 description = "CPax: A JAX-based computational physics library."
 authors = [
   { name = "Jan Lukas Späh", email = "your.email@example.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "CPax"
-version = "2025.4.0"
+version = "2025.5.0"
 description = "CPax: A JAX-based computational physics library."
 authors = [
   { name = "Jan Lukas Späh", email = "your.email@example.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "CPax"
-version = "v2025.3.0"
+version = "2025.4.0"
 description = "CPax: A JAX-based computational physics library."
 authors = [
   { name = "Jan Lukas Späh", email = "your.email@example.com" }
@@ -30,6 +30,7 @@ dependencies = [
 dev = [
   "flake8",
   "pytest",
+  "bump-my-version",
 ]
 test = [
   "pytest",

--- a/src/cpax/__init__.py
+++ b/src/cpax/__init__.py
@@ -1,4 +1,7 @@
 # cpax/__init__.py
 
+from importlib.metadata import version
+__version__ = version("cpax")
+
 # Import submodules but don’t expose specific functions
 from . import ode


### PR DESCRIPTION
This pull request introduces a manual release workflow using Calendar Versioning (CalVer), updates versioning practices, and integrates version management into the project. The most important changes include adding a GitHub Actions workflow for manual releases, configuring the `bump-my-version` tool, dynamically managing the package version, and updating dependencies.

### Workflow and Versioning Enhancements:

* **New GitHub Actions Workflow**: Added a manual release workflow (`.github/workflows/manual-release.yaml`) that uses `bump-my-version` to increment the patch version, create a Git tag, and push the changes. This enables manual CalVer-based releases.
* **`bump-my-version` Configuration**: Added a `bumpversion.toml` file to define the CalVer versioning scheme, including parsing, serialization, and tagging rules. The configuration supports year, month, and patch components.

### Codebase Updates for Dynamic Versioning:

* **Dynamic Version Retrieval**: Updated `docs/source/conf.py` and `src/cpax/__init__.py` to dynamically retrieve the package version using `importlib.metadata.version`. This ensures consistency across the project. [[1]](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698R12-R18) [[2]](diffhunk://#diff-ecd1fdca96877568a84a4a8f4c177a3ecac68347389c2de56b503c39a23569b6R3-R5)

### Dependency Management:

* **New Development Dependency**: Added `bump-my-version` to the development dependencies in `pyproject.toml` to support version management.

### Minor Adjustments:

* **Version Update in `pyproject.toml`**: Updated the `version` field to reflect the new release version (`2025.4.0`).