### PR TITLE
Setup git for manual release action

### DIFF
--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -17,6 +17,11 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Configure Git for the runner
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to configure Git for the runner in the manual release process.

Workflow improvements:

* [`.github/workflows/manual-release.yaml`](diffhunk://#diff-ba764e03d0b13a57755ef0e32238d5c99aee428268ac08bd62160f5ee6bbd1c1R20-R24): Added a step to configure Git with the runner's username and email to ensure proper Git operations during the workflow.