### PR TITLE
Hotfix versioning readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,9 @@ sphinx:
 
 # declare the Python requirements required to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# Install the package itself so that the version can be fetched dynamically during docs building (see docs/source/conf.py)
 python:
-   install:
-   - requirements: docs/requirements.txt
+  install:
+    - method: pip
+      path: .
+      extra_requirements: [docs]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,13 @@
 
 import os
 import sys
-from cpax import __version__
+try:
+    from cpax import __version__
+except (ImportError, AttributeError) as e:
+    raise RuntimeError(
+        "Failed to import `__version__` from the `cpax` package. Ensure that the `cpax` package is installed "
+        "and contains a `__version__` attribute."
+    ) from e
 sys.path.insert(0, os.path.abspath('../../src'))
 
 project = 'CPax'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,12 +8,12 @@
 
 import os
 import sys
+from cpax import __version__
 sys.path.insert(0, os.path.abspath('../../src'))
 
 project = 'CPax'
 copyright = '2025, Jan Lukas Späh'
 author = 'Jan Lukas Späh'
-from cpax import __version__
 release = __version__
 version = ".".join(release.split(".")[:2])
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,12 +9,12 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../../src'))
-import importlib.metadata
 
 project = 'CPax'
 copyright = '2025, Jan Lukas Späh'
 author = 'Jan Lukas Späh'
-release = importlib.metadata.version("cpax")
+from cpax import __version__
+release = __version__
 version = ".".join(release.split(".")[:2])
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This pull request updates the version retrieval method in the Sphinx configuration file. Instead of taking the version from the installed package (which was not installed by mistake before), it is imported.

Key change:

* [`docs/source/conf.py`](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698L12-R17): Replaced the use of `importlib.metadata.version` with direct import of the `__version__` attribute from the `cpax` package to determine the project version. This ensures consistency and simplifies version management.