### PR TITLE
Only CI with push to main or PR to any branch

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,9 @@ name: lint
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "*" ]
 
 jobs:
   lint:

--- a/.github/workflows/ode.yaml
+++ b/.github/workflows/ode.yaml
@@ -1,9 +1,11 @@
 name: Test ODE module
+
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "*" ]
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates branch filtering rules in GitHub Actions workflows to align with standard practices: Run with push on main and PR to any branch.

### Workflow updates:

* [`.github/workflows/lint.yaml`](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL5-R7): Modified the `push` event to trigger only on the `main` branch and the `pull_request` event to trigger on all branches.
* [`.github/workflows/ode.yaml`](diffhunk://#diff-b216456fe4ecb21e7b49cb4d4d691cd695ba0e19d68c3a2650e754eed8902ee4R2-R8): Updated the `push` event to trigger only on the `main` branch and the `pull_request` event to trigger on all branches.